### PR TITLE
better error reporting

### DIFF
--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -8,4 +8,5 @@ internal interface AuthEngine {
     fun clear()
     var onWakeThreads: ()->Unit
     fun runOnUiThread(block: ()->Unit)
+    val loginWasCancelled: Boolean
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthResult.kt
@@ -1,0 +1,7 @@
+package dk.ufst.ticketauth
+
+enum class AuthResult {
+    SUCCESS,
+    CANCELLED_FLOW,
+    ERROR
+}

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
@@ -3,6 +3,6 @@ package dk.ufst.ticketauth
 interface Authenticator {
     fun login()
     fun logout()
-    fun prepareCall(): Boolean
+    fun prepareCall(): AuthResult
     fun clearToken()
 }


### PR DESCRIPTION
Introduces a more detailed result enum class when calling prepareCall instead of just a boolean. This makes it possible for the client to know if user dismissed the login flow