### PR TITLE
new features & fixes

### DIFF
--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -1,5 +1,7 @@
 package dk.ufst.ticketauth
 
+typealias OnNewAccessTokenCallback = ((String)->Unit)?
+
 internal interface AuthEngine {
     fun launchAuthIntent()
     fun launchLogoutIntent()

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -9,4 +9,6 @@ internal interface AuthEngine {
     var onWakeThreads: ()->Unit
     fun runOnUiThread(block: ()->Unit)
     val loginWasCancelled: Boolean
+    val roles: List<String>
+    val accessToken: String?
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -32,13 +32,13 @@ internal class AuthEngineImpl(
     private val dcsBaseUrl: String,
     private val clientId: String,
     private val scopes: String,
+    private val redirectUri: String
 ): AuthEngine {
     private var authService: AuthorizationService = AuthorizationService(context)
     private var serviceConfig : AuthorizationServiceConfiguration
     var authState: AuthState = AuthState()
-    private val redirectUri: String = "${context.packageName}.ticketauth://callback?"
 
-    private val roles = mutableListOf<String>()
+    override val roles = mutableListOf<String>()
 
     private val refreshLock = ReentrantLock()
     private val refreshCondition: Condition = refreshLock.newCondition()
@@ -55,6 +55,13 @@ internal class AuthEngineImpl(
             } else {
                 false
             }
+
+    override val accessToken: String?
+        get() {
+            return authState.accessToken
+        }
+
+    override fun needsTokenRefresh(): Boolean = authState.needsTokenRefresh
 
     init {
         serviceConfig = buildServiceConfig()
@@ -144,8 +151,6 @@ internal class AuthEngineImpl(
             log("Cannot call logout endpoint because we have no idToken")
         }
     }
-
-    override fun needsTokenRefresh(): Boolean = authState.needsTokenRefresh
 
     private fun processLogoutResult(result: ActivityResult) {
         log("processLogoutResult $result")

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
@@ -7,4 +7,6 @@ interface Authenticator {
     fun logout()
     fun prepareCall(): AuthResult
     fun clearToken()
+    val accessToken: String?
+    val roles: List<String>
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
@@ -71,7 +71,9 @@ internal class AuthenticatorImpl(
     }
 
     override fun clearToken() = engine.clear()
-    override val accessToken: String? = engine.accessToken
+    override val accessToken: String?
+        get() = engine.accessToken
+
     override val roles: List<String> = engine.roles
 
     private fun wakeThreads() {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
@@ -20,7 +20,8 @@ object TicketAuth {
             context = config.context,
             dcsBaseUrl = config.dcsBaseUrl,
             clientId = config.clientId,
-            scopes = config.scopes
+            scopes = config.scopes,
+            redirectUri = config.redirectUri
         )
         authenticator = AuthenticatorImpl(engine!!)
     }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
@@ -21,7 +21,8 @@ object TicketAuth {
             dcsBaseUrl = config.dcsBaseUrl,
             clientId = config.clientId,
             scopes = config.scopes,
-            redirectUri = config.redirectUri
+            redirectUri = config.redirectUri,
+            onNewAccessToken = config.onNewAccessTokenCallback
         )
         authenticator = AuthenticatorImpl(engine!!)
     }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuthConfig.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuthConfig.kt
@@ -13,6 +13,7 @@ class TicketAuthConfig private constructor(
     val clientId: String,
     val scopes: String,
     val redirectUri: String,
+    val onNewAccessTokenCallback: OnNewAccessTokenCallback
 ) {
     data class Builder(
         private var sharedPrefs: SharedPreferences? = null,
@@ -22,6 +23,7 @@ class TicketAuthConfig private constructor(
         private var clientId: String? = null,
         private var scopes: String? = null,
         private var redirectUri: String? = null,
+        private var onNewAccessTokenCallback: OnNewAccessTokenCallback = null
     ) {
         fun sharedPrefs(sharedPreferences: SharedPreferences) = apply { this.sharedPrefs = sharedPreferences }
         fun context(context: Context) = apply { this.context = context }
@@ -30,6 +32,7 @@ class TicketAuthConfig private constructor(
         fun clientId(clientId: String) = apply { this.clientId = clientId }
         fun scopes(scopes: String) = apply { this.scopes = scopes }
         fun redirectUri(uri: String) = apply { this.redirectUri = uri }
+        fun onNewAccessToken(callback: OnNewAccessTokenCallback) = apply { this.onNewAccessTokenCallback = callback}
         fun build() = TicketAuthConfig(
             sharedPrefs ?: throw(RuntimeException("sharedPrefs is required")),
             context ?: throw(RuntimeException("context is required")),
@@ -37,7 +40,8 @@ class TicketAuthConfig private constructor(
             dcsBaseUrl ?: throw(RuntimeException("dcsBaseUrl is required")),
             clientId ?: throw(RuntimeException("clientId is required")),
             scopes ?: throw(RuntimeException("scopes is required")),
-            redirectUri ?: "${context!!.packageName}.ticketauth://callback?"
+            redirectUri ?: "${context!!.packageName}.ticketauth://callback?",
+            onNewAccessTokenCallback,
         )
     }
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuthConfig.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuthConfig.kt
@@ -12,6 +12,7 @@ class TicketAuthConfig private constructor(
     val dcsBaseUrl: String,
     val clientId: String,
     val scopes: String,
+    val redirectUri: String,
 ) {
     data class Builder(
         private var sharedPrefs: SharedPreferences? = null,
@@ -20,6 +21,7 @@ class TicketAuthConfig private constructor(
         private var dcsBaseUrl: String? = null,
         private var clientId: String? = null,
         private var scopes: String? = null,
+        private var redirectUri: String? = null,
     ) {
         fun sharedPrefs(sharedPreferences: SharedPreferences) = apply { this.sharedPrefs = sharedPreferences }
         fun context(context: Context) = apply { this.context = context }
@@ -27,12 +29,15 @@ class TicketAuthConfig private constructor(
         fun dcsBaseUrl(url: String) = apply { this.dcsBaseUrl = url }
         fun clientId(clientId: String) = apply { this.clientId = clientId }
         fun scopes(scopes: String) = apply { this.scopes = scopes }
+        fun redirectUri(uri: String) = apply { this.redirectUri = uri }
         fun build() = TicketAuthConfig(
             sharedPrefs ?: throw(RuntimeException("sharedPrefs is required")),
             context ?: throw(RuntimeException("context is required")),
             debug,
             dcsBaseUrl ?: throw(RuntimeException("dcsBaseUrl is required")),
             clientId ?: throw(RuntimeException("clientId is required")),
-            scopes ?: throw(RuntimeException("scopes is required")))
+            scopes ?: throw(RuntimeException("scopes is required")),
+            redirectUri ?: "${context!!.packageName}.ticketauth://callback?"
+        )
     }
 }


### PR DESCRIPTION
- client can now pass a callback to Authenticator.login() which gets called with the AuthResult
- redirectUri can be specified in TicketAuthConfig.Builder
- onNewAccessToken callback can be passed to TicketAuthConfig.Builder
- fixed a bug where accessToken accessors would save and return initial value instead of calling source object
- fixed a null pointer exception when using  the callback to Authenticator.login()