### PR TITLE
Feature logout callback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,25 @@ If you want to run the oauth logout flow call:
 authenticator.logout()
 ```
 
+#### Get notified when logout flow is complete
+It is possible to get called back whenever the logout flow is completed.
+
+```
+TicketAuth.authenticator().logout { result ->
+    when(result) {
+        AuthResult.SUCCESS -> {
+            // do something
+        }
+        AuthResult.CANCELLED_FLOW -> {
+            // do something
+        }
+        AuthResult.ERROR -> {
+            // do something
+        }
+    }
+}
+```
+
 ### Clear token manually
 You might need to clear the current auth state (and all tokens) manually on the response
 to some event. To do this call:

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -11,6 +11,7 @@ internal interface AuthEngine {
     var onWakeThreads: ()->Unit
     fun runOnUiThread(block: ()->Unit)
     val loginWasCancelled: Boolean
+    val logoutWasCancelled: Boolean
     val roles: List<String>
     val accessToken: String?
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -57,6 +57,16 @@ internal class AuthEngineImpl(
                 false
             }
 
+    private var logoutCancelled: Boolean = false
+    override val logoutWasCancelled: Boolean
+        get() = if(logoutCancelled) {
+            logoutCancelled = false
+            true
+        } else {
+            false
+        }
+
+
     override val accessToken: String?
         get() = authState.accessToken
 
@@ -154,6 +164,11 @@ internal class AuthEngineImpl(
 
     private fun processLogoutResult(result: ActivityResult) {
         log("processLogoutResult $result")
+        if(result.resultCode == Activity.RESULT_CANCELED) {
+            logoutCancelled = true
+            onWakeThreads()
+            return
+        }
         result.data?.let { data ->
             val resp = EndSessionResponse.fromIntent(data)
             val ex = AuthorizationException.fromIntent(data)

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -44,8 +44,8 @@ internal class AuthEngineImpl(
     private val refreshLock = ReentrantLock()
     private val refreshCondition: Condition = refreshLock.newCondition()
     var activityProvider: ActivityProvider = null
-    private lateinit var startForResultAuth: ActivityResultLauncher<Intent?>
-    private lateinit var startForResultLogout: ActivityResultLauncher<Intent?>
+    private var startForResultAuth: ActivityResultLauncher<Intent?>? = null
+    private var startForResultLogout: ActivityResultLauncher<Intent?>? = null
     override var onWakeThreads: ()->Unit = {}
 
     private var loginCancelled: Boolean = false
@@ -118,7 +118,7 @@ internal class AuthEngineImpl(
 
         val authIntent: Intent = authService.getAuthorizationRequestIntent(authRequest)
 
-        startForResultAuth.launch(authIntent)
+        startForResultAuth!!.launch(authIntent)
     }
 
     private fun processAuthResult(result: ActivityResult) {
@@ -156,7 +156,7 @@ internal class AuthEngineImpl(
                 .setPostLogoutRedirectUri(Uri.parse(redirectUri))
                 .build()
             val endSessionIntent = authService.getEndSessionRequestIntent(endSessionRequest)
-            startForResultLogout.launch(endSessionIntent)
+            startForResultLogout!!.launch(endSessionIntent)
         } ?: run {
             log("Cannot call logout endpoint because we have no idToken")
         }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/Authenticator.kt
@@ -1,10 +1,10 @@
 package dk.ufst.ticketauth
 
-typealias LoginCallback = (AuthResult)->Unit
+typealias AuthCallback = (AuthResult)->Unit
 
 interface Authenticator {
-    fun login(callback: LoginCallback? = null)
-    fun logout()
+    fun login(callback: AuthCallback? = null)
+    fun logout(callback: AuthCallback? = null)
     fun prepareCall(): AuthResult
     fun clearToken()
     val accessToken: String?


### PR DESCRIPTION
- its now possible to pass a callback to Authenticator.logout inorder to get notified whether logout flow is completed, aborted or failed
- fixed a bug with ActivityResultLaunchers stored in lateinit vars 