### PR TITLE
Bugfix/lockup issue

### DIFF
--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -10,8 +10,9 @@ internal interface AuthEngine {
     fun clear()
     var onWakeThreads: ()->Unit
     fun runOnUiThread(block: ()->Unit)
-    val loginWasCancelled: Boolean
-    val logoutWasCancelled: Boolean
+
+    val jobs: MutableMap<Int, AuthJob>
+
     val roles: List<String>
     val accessToken: String?
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -205,11 +205,9 @@ internal class AuthEngineImpl(
     private fun wakeThreads(result: AuthResult) {
         for(job in jobs.values) {
             job.result = result
-            job.callback?.let {
-                val localCallback = it
-                runOnUiThread { localCallback(result) }
-            }
+            job.callback?.invoke(result)
         }
+        jobs.entries.removeIf { it.value.noReturn }
         onWakeThreads()
     }
 

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -53,10 +53,6 @@ internal class AuthEngineImpl(
     override val accessToken: String?
         get() = authState.accessToken
     
-    //private var jobRunningAuth: Int = 0
-    //private var jobRunningLogout: Int = 0
-
-
     override fun needsTokenRefresh(): Boolean = authState.needsTokenRefresh
 
     init {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -47,28 +47,14 @@ internal class AuthEngineImpl(
     private var startForResultAuth: ActivityResultLauncher<Intent?>? = null
     private var startForResultLogout: ActivityResultLauncher<Intent?>? = null
     override var onWakeThreads: ()->Unit = {}
-
-    private var loginCancelled: Boolean = false
-    override val loginWasCancelled: Boolean
-        get() = if(loginCancelled) {
-                loginCancelled = false
-                true
-            } else {
-                false
-            }
-
-    private var logoutCancelled: Boolean = false
-    override val logoutWasCancelled: Boolean
-        get() = if(logoutCancelled) {
-            logoutCancelled = false
-            true
-        } else {
-            false
-        }
-
+    
+    override val jobs: MutableMap<Int, AuthJob> = mutableMapOf()
 
     override val accessToken: String?
         get() = authState.accessToken
+    
+    //private var jobRunningAuth: Int = 0
+    //private var jobRunningLogout: Int = 0
 
 
     override fun needsTokenRefresh(): Boolean = authState.needsTokenRefresh
@@ -117,15 +103,41 @@ internal class AuthEngineImpl(
             .build()
 
         val authIntent: Intent = authService.getAuthorizationRequestIntent(authRequest)
-
-        startForResultAuth!!.launch(authIntent)
+        
+        try {
+            startForResultAuth!!.launch(authIntent)
+        } catch (t : Throwable) {
+            log("Cannot launch auth intent due to exception: ${t.message}")
+            wakeThreads(AuthResult.ERROR)
+        }
     }
+
+    override fun launchLogoutIntent() {
+        log("Launching logout intent")
+        authState.idToken?.let {
+            val endSessionRequest = EndSessionRequest.Builder(serviceConfig)
+                .setIdTokenHint(it)
+                .setPostLogoutRedirectUri(Uri.parse(redirectUri))
+                .build()
+            val endSessionIntent = authService.getEndSessionRequestIntent(endSessionRequest)
+            try {
+                startForResultLogout!!.launch(endSessionIntent)
+            } catch (t : Throwable) {
+                log("Cannot launch logout intent due to exception: ${t.message}")
+                wakeThreads(AuthResult.ERROR)
+            }
+        } ?: run {
+            log("Cannot launch logout intent because we have no idToken")
+            wakeThreads(AuthResult.ERROR)
+        }
+    }
+
 
     private fun processAuthResult(result: ActivityResult) {
         log("processAuthResult $result")
         if(result.resultCode == Activity.RESULT_CANCELED) {
-            loginCancelled = true
-            onWakeThreads()
+            log("Auth flow was cancelled by user")
+            wakeThreads(AuthResult.CANCELLED_FLOW)
         } else {
             result.data?.let { data ->
                 val resp = AuthorizationResponse.fromIntent(data)
@@ -138,35 +150,20 @@ internal class AuthEngineImpl(
                     log("Got auth code: ${resp.authorizationCode}")
                 } else {
                     log("Auth failed: $ex")
-                    // user cancelled login flow, wake threads so they can return error
-                    onWakeThreads()
+                    // user cancelled login flow (in flow cancel option), wake threads so they can return error
+                    wakeThreads(AuthResult.ERROR)
                 }
             } ?: run {
                 log("ActivityResult yielded no data (intent) to process")
-                onWakeThreads()
+                wakeThreads(AuthResult.ERROR)
             }
         }
     }
-
-    override fun launchLogoutIntent() {
-        log("Launching logout intent")
-        authState.idToken?.let {
-            val endSessionRequest = EndSessionRequest.Builder(serviceConfig)
-                .setIdTokenHint(it)
-                .setPostLogoutRedirectUri(Uri.parse(redirectUri))
-                .build()
-            val endSessionIntent = authService.getEndSessionRequestIntent(endSessionRequest)
-            startForResultLogout!!.launch(endSessionIntent)
-        } ?: run {
-            log("Cannot call logout endpoint because we have no idToken")
-        }
-    }
-
+    
     private fun processLogoutResult(result: ActivityResult) {
         log("processLogoutResult $result")
         if(result.resultCode == Activity.RESULT_CANCELED) {
-            logoutCancelled = true
-            onWakeThreads()
+            wakeThreads(AuthResult.CANCELLED_FLOW)
             return
         }
         result.data?.let { data ->
@@ -175,13 +172,16 @@ internal class AuthEngineImpl(
             if (resp != null) {
                 log("Completed logout")
                 clear()
+                wakeThreads(AuthResult.SUCCESS)
             } else {
+                wakeThreads(AuthResult.ERROR)
                 log("Logout failed: $ex")
             }
         } ?: run {
+            wakeThreads(AuthResult.ERROR)
             log("ActivityResult yielded no data (intent) to process")
         }
-        onWakeThreads()
+
     }
 
     private fun performTokenRequest(authResp: AuthorizationResponse) {
@@ -194,11 +194,23 @@ internal class AuthEngineImpl(
                 log("Got access token: ${resp.accessToken}")
                 decodeJWT()
                 onAccessToken()
-                onWakeThreads()
+                wakeThreads(AuthResult.SUCCESS)
             } else {
                 log("Token exchange failed: $ex")
+                wakeThreads(AuthResult.ERROR)
             }
         }
+    }
+
+    private fun wakeThreads(result: AuthResult) {
+        for(job in jobs.values) {
+            job.result = result
+            job.callback?.let {
+                val localCallback = it
+                runOnUiThread { localCallback(result) }
+            }
+        }
+        onWakeThreads()
     }
 
     /**

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthJob.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthJob.kt
@@ -3,5 +3,6 @@ package dk.ufst.ticketauth
 data class AuthJob (
     var id: Int = 0,
     var result: AuthResult? = null,
-    var callback: AuthCallback? = null
+    var callback: AuthCallback? = null,
+    var noReturn: Boolean = false
 )

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthJob.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthJob.kt
@@ -1,0 +1,7 @@
+package dk.ufst.ticketauth
+
+data class AuthJob (
+    var id: Int = 0,
+    var result: AuthResult? = null,
+    var callback: AuthCallback? = null
+)

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
@@ -19,7 +19,7 @@ internal class AuthenticatorImpl(
 
     override fun login(callback: AuthCallback?) {
         if(latch.compareAndSet(null, CountDownLatch(1))) {
-            val job = spawnJob()
+            val job = spawnJob(noReturn = true)
             job.callback = callback
             engine.clear()
             engine.runOnUiThread {
@@ -32,7 +32,7 @@ internal class AuthenticatorImpl(
 
     override fun logout(callback: AuthCallback?) {
         if(latch.compareAndSet(null, CountDownLatch(1))) {
-            val job = spawnJob()
+            val job = spawnJob(noReturn = true)
             job.callback = callback
             engine.runOnUiThread {
                 engine.launchLogoutIntent()
@@ -44,7 +44,7 @@ internal class AuthenticatorImpl(
     }
 
     override fun prepareCall(): AuthResult {
-        val job = spawnJob()
+        val job = spawnJob(noReturn = false)
         var result = AuthResult.SUCCESS
         if(engine.needsTokenRefresh()) {
             log("Token needs refresh, pausing network call")
@@ -74,8 +74,8 @@ internal class AuthenticatorImpl(
         return result
     }
 
-    private fun spawnJob(): AuthJob {
-        val job = AuthJob(id = nextJobId)
+    private fun spawnJob(noReturn: Boolean = false): AuthJob {
+        val job = AuthJob(id = nextJobId, noReturn = noReturn)
         engine.jobs[nextJobId] = job
         nextJobId++
         return job

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicReference
 internal class AuthenticatorImpl(
     private var engine: AuthEngine
 ): Authenticator {
+    private var nextJobId: Int = 1
+
     init {
         engine.onWakeThreads = {
             wakeThreads()
@@ -14,12 +16,11 @@ internal class AuthenticatorImpl(
     }
 
     private var latch: AtomicReference<CountDownLatch> = AtomicReference()
-    private var loginCallback: AuthCallback? = null
-    private var logoutCallback: AuthCallback? = null
 
     override fun login(callback: AuthCallback?) {
         if(latch.compareAndSet(null, CountDownLatch(1))) {
-            loginCallback = callback
+            val job = spawnJob()
+            job.callback = callback
             engine.clear()
             engine.runOnUiThread {
                 engine.launchAuthIntent()
@@ -31,7 +32,8 @@ internal class AuthenticatorImpl(
 
     override fun logout(callback: AuthCallback?) {
         if(latch.compareAndSet(null, CountDownLatch(1))) {
-            logoutCallback = callback
+            val job = spawnJob()
+            job.callback = callback
             engine.runOnUiThread {
                 engine.launchLogoutIntent()
                 engine.clear()
@@ -42,6 +44,8 @@ internal class AuthenticatorImpl(
     }
 
     override fun prepareCall(): AuthResult {
+        val job = spawnJob()
+        var result = AuthResult.SUCCESS
         if(engine.needsTokenRefresh()) {
             log("Token needs refresh, pausing network call")
             // first caller creates the latch and waits, subsequent callers just wait on the latch
@@ -60,16 +64,25 @@ internal class AuthenticatorImpl(
             }
             // goto sleep until wakeThreads is called
             latch.get()?.await()
-            if(engine.loginWasCancelled) {
-                log("Thread woke up but user cancelled the login flow, return error")
-                return AuthResult.CANCELLED_FLOW
-            }
-            if(engine.needsTokenRefresh()) {
-                log("Thread woke up but TicketAuth didn't manage to obtain a new token, return error")
-                return AuthResult.ERROR
+
+            job.result?.let {
+                log("Thread woke up but found pending AuthResult: ${it.name}, return result")
+                result = it
             }
         }
-        return AuthResult.SUCCESS
+        killJob(job)
+        return result
+    }
+
+    private fun spawnJob(): AuthJob {
+        val job = AuthJob(id = nextJobId)
+        engine.jobs[nextJobId] = job
+        nextJobId++
+        return job
+    }
+
+    private fun killJob(job: AuthJob) {
+        engine.jobs.remove(job.id)
     }
 
     override fun clearToken() = engine.clear()
@@ -80,22 +93,5 @@ internal class AuthenticatorImpl(
 
     private fun wakeThreads() {
         latch.getAndSet(null).countDown()
-        if(loginCallback != null) {
-            val localCallback = loginCallback
-            loginCallback = null
-            when(true) {
-                engine.loginWasCancelled -> engine.runOnUiThread { localCallback!!(AuthResult.CANCELLED_FLOW) }
-                engine.needsTokenRefresh() -> engine.runOnUiThread { localCallback!!(AuthResult.ERROR) }
-                else -> engine.runOnUiThread { localCallback!!(AuthResult.SUCCESS) }
-            }
-        }
-        if(logoutCallback != null) {
-            val localCallback = logoutCallback
-            logoutCallback = null
-            when(true) {
-                engine.logoutWasCancelled -> engine.runOnUiThread { localCallback!!(AuthResult.CANCELLED_FLOW) }
-                else -> engine.runOnUiThread { localCallback!!(AuthResult.SUCCESS) }
-            }
-        }
     }
 }


### PR DESCRIPTION
- fixes an issue where login() or logout() is called but returns due to an error without releasing a lock. This results in a deadlock since network requests will wait forever after
- fixes an issue where if there is more than one paused network call and the user cancels a webflow, only the first call would return AuthResult.CANCELLED_FLOW, the rest would return AuthResult.ERROR