### PR TITLE
fixed leaked service connection

### DIFF
--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngine.kt
@@ -10,6 +10,7 @@ internal interface AuthEngine {
     fun clear()
     var onWakeThreads: ()->Unit
     fun runOnUiThread(block: ()->Unit)
+    fun destroy()
 
     val jobs: MutableMap<Int, AuthJob>
 

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthEngineImpl.kt
@@ -284,6 +284,10 @@ internal class AuthEngineImpl(
         }
     }
 
+    override fun destroy() {
+        authService.dispose()
+    }
+
     companion object {
         private const val AUTH_PATH: String = "/protocol/openid-connect/auth"
         private const val TOKEN_PATH: String = "/protocol/openid-connect/token"

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/AuthenticatorImpl.kt
@@ -92,6 +92,6 @@ internal class AuthenticatorImpl(
     override val roles: List<String> = engine.roles
 
     private fun wakeThreads() {
-        latch.getAndSet(null).countDown()
+        latch.getAndSet(null)?.countDown()
     }
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
@@ -15,6 +15,7 @@ object TicketAuth {
 
     fun setup(config: TicketAuthConfig) {
         debug = config.debug
+        engine?.destroy()
         engine = AuthEngineImpl(
             sharedPrefs = config.sharedPrefs,
             context = config.context,


### PR DESCRIPTION
- AuthorizationService should no longer leak since we are now calling its cleanup function (destroy) each time we instantiate a new AuthEngine