### PR TITLE
Feature/pkce

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,14 @@ TicketAuth.setup(
 ```
 Auth state is automatically persisted between application restarts.
 
+#### PKCE
+PKCE is enabled by default. To turn it off use:
+```kotlin
+    .usePKCE(false)
+```
+
+__There is no good reason to turn off PKCE, unless the authentication server doesn't support it__ 
+
 #### redirectUri
 The library generates a default redirectUri which is package name + ".ticketauth" if you for one
 reason or another needs to manually specify a redirectUri, call this function:

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/TicketAuth.kt
@@ -28,7 +28,8 @@ object TicketAuth {
             scopes = config.scopes,
             redirectUri = config.redirectUri,
             onNewAccessToken = config.onNewAccessTokenCallback,
-            onAuthResultCallback = config.onAuthResultCallback
+            onAuthResultCallback = config.onAuthResultCallback,
+            usePKSE = config.usePKSE
         )
         authenticator = AuthenticatorImpl(engine!!)
     }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/AuthCodeConfig.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/AuthCodeConfig.kt
@@ -13,7 +13,8 @@ class AuthCodeConfig private constructor(
     val scopes: String,
     val redirectUri: String,
     val onNewAccessTokenCallback: OnNewAccessTokenCallback,
-    val onAuthResultCallback: OnAuthResultCallback
+    val onAuthResultCallback: OnAuthResultCallback,
+    val usePKSE: Boolean
 ) {
     data class Builder(
         private var debug: Boolean = false,
@@ -23,6 +24,7 @@ class AuthCodeConfig private constructor(
         private var redirectUri: String? = null,
         private var onNewAccessTokenCallback: OnNewAccessTokenCallback = null,
         private var onAuthResultCallback: OnAuthResultCallback = null,
+        private var usePKSE: Boolean = true
     ) {
         fun debug(debug: Boolean) = apply { this.debug = debug }
         fun dcsBaseUrl(url: String) = apply { this.dcsBaseUrl = url }
@@ -31,6 +33,7 @@ class AuthCodeConfig private constructor(
         fun redirectUri(uri: String) = apply { this.redirectUri = uri }
         fun onNewAccessToken(callback: OnNewAccessTokenCallback) = apply { this.onNewAccessTokenCallback = callback}
         fun onAuthResult(callback: OnAuthResultCallback) = apply { this.onAuthResultCallback = callback}
+        fun usePKSE(usePKSE: Boolean) = apply { this.usePKSE = usePKSE }
         fun build() = AuthCodeConfig(
             debug,
             dcsBaseUrl ?: throw(RuntimeException("dcsBaseUrl is required")),
@@ -38,7 +41,8 @@ class AuthCodeConfig private constructor(
             scopes ?: throw(RuntimeException("scopes is required")),
             redirectUri ?: "${hostApplicationContext!!.packageName}.ticketauth://callback?",
             onNewAccessTokenCallback,
-            onAuthResultCallback
+            onAuthResultCallback,
+            usePKSE
         )
     }
 }

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/PkceUtil.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/PkceUtil.kt
@@ -1,0 +1,155 @@
+package dk.ufst.ticketauth.authcode
+
+import android.util.Base64
+import dk.ufst.ticketauth.log
+import java.io.UnsupportedEncodingException
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.security.SecureRandom
+import java.util.regex.Pattern
+
+/**
+ * Generates code verifiers and challenges for PKCE exchange.
+ * Borrowed from AppAuth and converted to Kotlin
+ */
+object PkceUtil {
+    /**
+     * The minimum permitted length for a code verifier.
+     *
+     * @see "Proof Key for Code Exchange by OAuth Public Clients
+     */
+    private const val MIN_CODE_VERIFIER_LENGTH = 43
+
+    /**
+     * The maximum permitted length for a code verifier.
+     *
+     * @see "Proof Key for Code Exchange by OAuth Public Clients
+     */
+    private const val MAX_CODE_VERIFIER_LENGTH = 128
+
+    /**
+     * The default entropy (in bytes) used for the code verifier.
+     */
+    private const val DEFAULT_CODE_VERIFIER_ENTROPY = 64
+
+    /**
+     * The minimum permitted entropy (in bytes) for use with
+     * [.generateRandomCodeVerifier].
+     */
+    private const val MIN_CODE_VERIFIER_ENTROPY = 32
+
+    /**
+     * The maximum permitted entropy (in bytes) for use with
+     * [.generateRandomCodeVerifier].
+     */
+    private const val MAX_CODE_VERIFIER_ENTROPY = 96
+
+    /**
+     * Base64 encoding settings used for generated code verifiers.
+     */
+    private const val PKCE_BASE64_ENCODE_SETTINGS =
+        Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE
+
+    /**
+     * Regex for legal code verifier strings, as defined in the spec.
+     *
+     * @see "Proof Key for Code Exchange by OAuth Public Clients
+     */
+    private val REGEX_CODE_VERIFIER = Pattern.compile("^[0-9a-zA-Z\\-\\.\\_\\~]{43,128}$")
+
+    const val CODE_CHALLENGE_METHOD_S256 = "S256"
+
+    /**
+     * Plain-text code verifier challenge method. This is only used by AppAuth for Android if
+     * SHA-256 is not supported on this platform.
+     *
+     * @see "Proof Key for Code Exchange by OAuth Public Clients
+     */
+    const val CODE_CHALLENGE_METHOD_PLAIN = "plain"
+
+    /**
+     * Throws an IllegalArgumentException if the provided code verifier is invalid.
+     *
+     * @see "Proof Key for Code Exchange by OAuth Public Clients
+     */
+    fun checkCodeVerifier(codeVerifier: String) {
+        checkArgument(
+            MIN_CODE_VERIFIER_LENGTH <= codeVerifier.length,
+            "codeVerifier length is shorter than allowed by the PKCE specification"
+        )
+        checkArgument(
+            codeVerifier.length <= MAX_CODE_VERIFIER_LENGTH,
+            "codeVerifier length is longer than allowed by the PKCE specification"
+        )
+        checkArgument(
+            REGEX_CODE_VERIFIER.matcher(codeVerifier).matches(),
+            "codeVerifier string contains illegal characters"
+        )
+    }
+    /**
+     * Generates a random code verifier string using the provided entropy source and the specified
+     * number of bytes of entropy.
+     */
+    /**
+     * Generates a random code verifier string using [SecureRandom] as the source of
+     * entropy, with the default entropy quantity as defined by
+     * [.DEFAULT_CODE_VERIFIER_ENTROPY].
+     */
+    @JvmOverloads
+    fun generateRandomCodeVerifier(
+        entropySource: SecureRandom = SecureRandom(),
+        entropyBytes: Int = DEFAULT_CODE_VERIFIER_ENTROPY
+    ): String {
+        checkArgument(
+            MIN_CODE_VERIFIER_ENTROPY <= entropyBytes,
+            "entropyBytes is less than the minimum permitted"
+        )
+        checkArgument(
+            entropyBytes <= MAX_CODE_VERIFIER_ENTROPY,
+            "entropyBytes is greater than the maximum permitted"
+        )
+        val randomBytes = ByteArray(entropyBytes)
+        entropySource.nextBytes(randomBytes)
+        return Base64.encodeToString(randomBytes, PKCE_BASE64_ENCODE_SETTINGS)
+    }
+
+    /**
+     * Produces a challenge from a code verifier, using SHA-256 as the challenge method if the
+     * system supports it (all Android devices _should_ support SHA-256), and falls back
+     * to the [&quot;plain&quot; challenge type][AuthorizationRequest.CODE_CHALLENGE_METHOD_PLAIN] if
+     * unavailable.
+     */
+    fun deriveCodeVerifierChallenge(codeVerifier: String): String {
+        return try {
+            val sha256Digester = MessageDigest.getInstance("SHA-256")
+            sha256Digester.update(codeVerifier.toByteArray(charset("ISO_8859_1")))
+            val digestBytes = sha256Digester.digest()
+            Base64.encodeToString(digestBytes, PKCE_BASE64_ENCODE_SETTINGS)
+        } catch (e: NoSuchAlgorithmException) {
+            log("SHA-256 is not supported on this device! Using plain challenge")
+            codeVerifier
+        } catch (e: UnsupportedEncodingException) {
+            log("ISO-8859-1 encoding not supported on this device!")
+            throw IllegalStateException("ISO-8859-1 encoding not supported", e)
+        }
+    }// no exception, so SHA-256 is supported
+
+    /**
+     * Returns the challenge method utilized on this system: typically
+     * [SHA-256][AuthorizationRequest.CODE_CHALLENGE_METHOD_S256] if supported by
+     * the system, [plain][AuthorizationRequest.CODE_CHALLENGE_METHOD_PLAIN] otherwise.
+     */
+    val codeVerifierChallengeMethod: String
+        get() = try {
+            MessageDigest.getInstance("SHA-256")
+            // no exception, so SHA-256 is supported
+            CODE_CHALLENGE_METHOD_S256
+        } catch (e: NoSuchAlgorithmException) {
+            CODE_CHALLENGE_METHOD_PLAIN
+        }
+
+    private fun checkArgument(expression: Boolean, errorMessage: Any?) {
+        require(expression) { errorMessage.toString() }
+    }
+}
+

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/PkceUtil.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/PkceUtil.kt
@@ -6,27 +6,12 @@ import java.io.UnsupportedEncodingException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.security.SecureRandom
-import java.util.regex.Pattern
 
 /**
  * Generates code verifiers and challenges for PKCE exchange.
  * Borrowed from AppAuth and converted to Kotlin
  */
 object PkceUtil {
-    /**
-     * The minimum permitted length for a code verifier.
-     *
-     * @see "Proof Key for Code Exchange by OAuth Public Clients
-     */
-    private const val MIN_CODE_VERIFIER_LENGTH = 43
-
-    /**
-     * The maximum permitted length for a code verifier.
-     *
-     * @see "Proof Key for Code Exchange by OAuth Public Clients
-     */
-    private const val MAX_CODE_VERIFIER_LENGTH = 128
-
     /**
      * The default entropy (in bytes) used for the code verifier.
      */
@@ -50,14 +35,7 @@ object PkceUtil {
     private const val PKCE_BASE64_ENCODE_SETTINGS =
         Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE
 
-    /**
-     * Regex for legal code verifier strings, as defined in the spec.
-     *
-     * @see "Proof Key for Code Exchange by OAuth Public Clients
-     */
-    private val REGEX_CODE_VERIFIER = Pattern.compile("^[0-9a-zA-Z\\-\\.\\_\\~]{43,128}$")
-
-    const val CODE_CHALLENGE_METHOD_S256 = "S256"
+    private const val CODE_CHALLENGE_METHOD_S256 = "S256"
 
     /**
      * Plain-text code verifier challenge method. This is only used by AppAuth for Android if
@@ -65,27 +43,8 @@ object PkceUtil {
      *
      * @see "Proof Key for Code Exchange by OAuth Public Clients
      */
-    const val CODE_CHALLENGE_METHOD_PLAIN = "plain"
+    private const val CODE_CHALLENGE_METHOD_PLAIN = "plain"
 
-    /**
-     * Throws an IllegalArgumentException if the provided code verifier is invalid.
-     *
-     * @see "Proof Key for Code Exchange by OAuth Public Clients
-     */
-    fun checkCodeVerifier(codeVerifier: String) {
-        checkArgument(
-            MIN_CODE_VERIFIER_LENGTH <= codeVerifier.length,
-            "codeVerifier length is shorter than allowed by the PKCE specification"
-        )
-        checkArgument(
-            codeVerifier.length <= MAX_CODE_VERIFIER_LENGTH,
-            "codeVerifier length is longer than allowed by the PKCE specification"
-        )
-        checkArgument(
-            REGEX_CODE_VERIFIER.matcher(codeVerifier).matches(),
-            "codeVerifier string contains illegal characters"
-        )
-    }
     /**
      * Generates a random code verifier string using the provided entropy source and the specified
      * number of bytes of entropy.
@@ -116,7 +75,7 @@ object PkceUtil {
     /**
      * Produces a challenge from a code verifier, using SHA-256 as the challenge method if the
      * system supports it (all Android devices _should_ support SHA-256), and falls back
-     * to the [&quot;plain&quot; challenge type][AuthorizationRequest.CODE_CHALLENGE_METHOD_PLAIN] if
+     * to the plain challenge type if
      * unavailable.
      */
     fun deriveCodeVerifierChallenge(codeVerifier: String): String {
@@ -136,8 +95,8 @@ object PkceUtil {
 
     /**
      * Returns the challenge method utilized on this system: typically
-     * [SHA-256][AuthorizationRequest.CODE_CHALLENGE_METHOD_S256] if supported by
-     * the system, [plain][AuthorizationRequest.CODE_CHALLENGE_METHOD_PLAIN] otherwise.
+     * SHA-256 if supported by
+     * the system, plain otherwise.
      */
     val codeVerifierChallengeMethod: String
         get() = try {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/RedirectUriParser.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/RedirectUriParser.kt
@@ -3,8 +3,8 @@ package dk.ufst.ticketauth.authcode
 import android.net.Uri
 
 /**
- * Parses the redirect uri and params. If an error is returned it is encoded in the fragment part
- * of the URI. Since android.net.Uri doesn't support parsing that part is being done here with
+ * Parses the redirect uri and params. If an error is returned it is encoded in the fragment/query part
+ * of the URI. Since android.net.Uri doesn't support parsing the fragment part is being done here with
  * regexes. This is generally not the optimal way (a tokenizer would be a better solution)
  */
 class RedirectUriParser {

--- a/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/RedirectUriParser.kt
+++ b/ticketauth/src/main/kotlin/dk/ufst/ticketauth/authcode/RedirectUriParser.kt
@@ -25,6 +25,12 @@ class RedirectUriParser {
             val code = uri.getQueryParameter("code")
             if(state != null && code != null) {
                 return ParsedResult.Success(code, state)
+            } else {
+                val error = uri.getQueryParameter("error")
+                val errorDescription = uri.getQueryParameter("error_description")
+                if(error != null && errorDescription != null) {
+                    return ParsedResult.Error(error, errorDescription)
+                }
             }
         } else {
             uri.fragment?.let { fragment ->


### PR DESCRIPTION
- fixed a bug where errors resulting from the authorization code request would not be correctly parsed
- implemented PKCE support. Enabled by default, but can be turned off by an optional usePKCE(boolean) argument to the AuthCode builder
- updated documentation